### PR TITLE
feat(FieldType): added enum back because used in novo. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bullhorn/taurus",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/types/FieldMap.ts
+++ b/src/types/FieldMap.ts
@@ -1,6 +1,15 @@
 /**
  * Enumeration of different field types associated with Bullhorn Data.
  */
+
+export enum FieldType {
+  ID = 'ID',
+  COMPOSITE = 'COMPOSITE',
+  TO_ONE = 'TO_ONE',
+  TO_MANY = 'TO_MANY',
+  SCALAR = 'SCALAR',
+}
+
 export interface FieldMapOption {
   value?: any;
   label?: string;
@@ -9,7 +18,7 @@ export interface FieldMapOption {
 
 export interface FieldMap {
   name: string;
-  type?: 'ID' | 'COMPOSITE' | 'TO_ONE' | 'TO_MANY' | 'SCALAR';
+  type?: FieldType | string;
   dataType?: string;
   dataSpecialization?: string;
   maxLength?: number;


### PR DESCRIPTION
Also set type to allow string, because Novo is setting type to "picker" in some forms, not sure how this is used quite yet. 