### PR TITLE
Alternative Check field associated entity and add missing fields

### DIFF
--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -284,8 +284,7 @@ export class MetaService {
       // Remove spaces, [] and {} bracket contents from fields if present
       .replace(/\s|(\{[^\}]*?\})|(\[[^\]]*?\])/gi, '')
       .match(/(?:\(([^)]*)\))/gi)[0]
-      .match(/[^,\(\)]+/gi)
-      || [];[]
+      .match(/[^,\(\)]+/gi) || [];
   }
 
   /**

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -281,7 +281,7 @@ export class MetaService {
 
   getSubFields(field: string): string[] {
     return field
-      // remove [] and {} bracket contents from fields if present
+      // Remove [] and {} bracket contents from fields if present
       .replace(/(\{[^\}]*?\})|(\[[^\]]*?\])/gi, '')
       .match(/(?:\([^)]*\)|[^,\s])+/gi) || [];
   }

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -265,7 +265,7 @@ export class MetaService {
         result.push(cleaned);
       } else if (meta.associatedEntity
         && meta.associatedEntity.fields
-        && meta.associatedEntity.fields.some(f => !this.getSubFields(fields).includes(f.name))) {
+        && meta.associatedEntity.fields.some(f => !this.getSubFields(field).includes(f.name))) {
         result.push(cleaned);
       }
     }
@@ -280,13 +280,10 @@ export class MetaService {
   }
 
   getSubFields(field: string): string[] {
-    if (field.includes('(')) {
-      return field
-        .split(')')[0]
-        .split('(')[1]
-        .split(',');
-    }
-    return [];
+    return field
+      // remove [] and {} bracket contents from fields if present
+      .replace(/(\{[^\}]*?\})|(\[[^\]]*?\])/gi, '')
+      .match(/(?:\([^)]*\)|[^,\s])+/gi) || [];
   }
 
   /**

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -261,7 +261,7 @@ export class MetaService {
     for (const field of fields) {
       const cleaned: string = this._clean(field);
       const meta: any = this.memory[cleaned];
-      if (!meta) {
+      if (!meta || meta.associatedEntity && meta.associatedEntity.fields.length < this.subFieldLength(field)) {
         result.push(cleaned);
       }
     }
@@ -273,6 +273,15 @@ export class MetaService {
       .split('.')[0]
       .split('[')[0]
       .split('(')[0];
+  }
+
+  subFieldLength(field: string): number {
+    if (field.includes('(')) {
+      return field
+        .split('(')[1]
+        .split(',').length - 1;
+    }
+    return 0;
   }
 
   /**

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -265,7 +265,7 @@ export class MetaService {
         result.push(cleaned);
       } else if (meta.associatedEntity
         && meta.associatedEntity.fields
-        && meta.associatedEntity.fields.some(f => !this.getSubFields(field).includes(f.name))) {
+        && this.getSubFields(field).some(subField => !meta.associatedEntity.fields.find(aef => aef.name === subField))) {
         result.push(cleaned);
       }
     }
@@ -281,9 +281,11 @@ export class MetaService {
 
   getSubFields(field: string): string[] {
     return field
-      // Remove [] and {} bracket contents from fields if present
+      // Remove spaces, [] and {} bracket contents from fields if present
       .replace(/\s|(\{[^\}]*?\})|(\[[^\]]*?\])/gi, '')
-      .match(/(?:\([^)]*\)|[^,\s])+/gi) || [];
+      .match(/(?:\(([^)]*)\))/gi)[0]
+      .match(/[^,\(\)]+/gi)
+      || [];[]
   }
 
   /**

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -197,6 +197,13 @@ export class MetaService {
         const exists = this.fields.find((f: any) => f.name === field.name);
         if (!exists) {
           this.fields.push(field);
+        } else if (field.associatedEntity && field.associatedEntity.fields) {
+          for (const assocEntityField of field.associatedEntity.fields) {
+            const assocEntityFieldExists = exists.associatedEntity.fields.find((f: any) => f.name === assocEntityField.name);
+            if(!assocEntityFieldExists) {
+              exists.associatedEntity.fields.push(assocEntityField)
+            }
+          }
         }
         if (typeof field !== 'string') {
           this.memory[field.name] = field;

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -199,7 +199,7 @@ export class MetaService {
           this.fields.push(field);
         } else if (field.associatedEntity && field.associatedEntity.fields) {
           for (const assocEntityField of field.associatedEntity.fields) {
-            const assocEntityFieldExists = exists.associatedEntity.fields.find((f: any) => f.name === assocEntityField.name);
+            const assocEntityFieldExists = exists.associatedEntity.fields.find((f: { name: string }) => f.name === assocEntityField.name);
             if (!assocEntityFieldExists) {
               exists.associatedEntity.fields.push(assocEntityField);
             }

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -279,7 +279,7 @@ export class MetaService {
     if (field.includes('(')) {
       return field
         .split('(')[1]
-        .split(',').length - 1;
+        .split(',').length;
     }
     return 0;
   }

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -263,7 +263,9 @@ export class MetaService {
       const meta: any = this.memory[cleaned];
       if (!meta) {
         result.push(cleaned);
-      } else if (meta.associatedEntity
+      } else if (
+        meta.dataSpecialization === 'INLINE_EMBEDDED'
+        && meta.associatedEntity
         && meta.associatedEntity.fields
         && this.getSubFields(field).some(subField => !meta.associatedEntity.fields.find(aef => aef.name === subField))) {
         result.push(cleaned);

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -261,7 +261,11 @@ export class MetaService {
     for (const field of fields) {
       const cleaned: string = this._clean(field);
       const meta: any = this.memory[cleaned];
-      if (!meta || meta.associatedEntity && meta.associatedEntity.fields.length < this.subFieldLength(field)) {
+      if (!meta) {
+        result.push(cleaned);
+      } else if (meta.associatedEntity
+        && meta.associatedEntity.fields
+        && meta.associatedEntity.fields.some(f => !this.getSubFields(fields).includes(f.name))) {
         result.push(cleaned);
       }
     }
@@ -275,13 +279,14 @@ export class MetaService {
       .split('(')[0];
   }
 
-  subFieldLength(field: string): number {
+  getSubFields(field: string): string[] {
     if (field.includes('(')) {
       return field
+        .split(')')[0]
         .split('(')[1]
-        .split(',').length;
+        .split(',');
     }
-    return 0;
+    return [];
   }
 
   /**

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -200,8 +200,8 @@ export class MetaService {
         } else if (field.associatedEntity && field.associatedEntity.fields) {
           for (const assocEntityField of field.associatedEntity.fields) {
             const assocEntityFieldExists = exists.associatedEntity.fields.find((f: any) => f.name === assocEntityField.name);
-            if(!assocEntityFieldExists) {
-              exists.associatedEntity.fields.push(assocEntityField)
+            if (!assocEntityFieldExists) {
+              exists.associatedEntity.fields.push(assocEntityField);
             }
           }
         }

--- a/src/services/MetaService.ts
+++ b/src/services/MetaService.ts
@@ -282,7 +282,7 @@ export class MetaService {
   getSubFields(field: string): string[] {
     return field
       // Remove [] and {} bracket contents from fields if present
-      .replace(/(\{[^\}]*?\})|(\[[^\]]*?\])/gi, '')
+      .replace(/\s|(\{[^\}]*?\})|(\[[^\]]*?\])/gi, '')
       .match(/(?:\([^)]*\)|[^,\s])+/gi) || [];
   }
 

--- a/src/utils/FieldUtils.ts
+++ b/src/utils/FieldUtils.ts
@@ -1,0 +1,102 @@
+export type FieldSyntax = [string, string[]];
+export type FieldSyntaxTree = (string | FieldSyntax)[];
+
+export function tokenize(str: string): string[] {
+  // Remove query syntax between `{` and `}`
+  let replaced = str.replace(/(\{[^\}]*?\})/gi, '');
+  // Remove count syntax between `[` and `]`
+  replaced = replaced.replace(/(\[[^\]]*?\])/gi, '');
+  // Remove any whitespace
+  replaced = replaced.replace(/\s/gi, '');
+  return replaced.match(/((\w+)|([\(\)\{\}\[\]]))/gi);
+}
+
+// Convert tokens into a psuedo syntax tree.
+export function parse(tokens: string[]): FieldSyntaxTree {
+  let curr: FieldSyntaxTree = [];
+  const stack: FieldSyntaxTree[] = [];
+  for (const token of tokens) {
+    switch (token) {
+      case '(':
+        stack.push(curr);
+        curr = [];
+        break;
+      case ')':
+        const tmp = stack.pop() || [];
+        const lastKey = (tmp.pop() as string) || '';
+        tmp.push([lastKey, curr as string[]]);
+        curr = tmp;
+        break;
+      default:
+        curr.push(token);
+    }
+  }
+  return curr;
+}
+
+// Parse a single field
+export function readField(str: string) {
+  return parse(tokenize(str))[0];
+}
+
+// Parse a list of fields as a string
+export function readFields(str: string) {
+  return parse(tokenize(str));
+}
+
+// Ensure all parsed fields returned as a tuple
+export function fieldTuple(field: string | FieldSyntax): FieldSyntax {
+  if (Array.isArray(field)) {
+    return field;
+  }
+  return [field, []];
+}
+
+export function stringify(fields: FieldSyntaxTree): string {
+  const formatted: string[] = fields.map((field) => {
+    const [key, children] = fieldTuple(field);
+    if (children.length) {
+      const nested = stringify(children);
+      return `${key}(${nested})`;
+    }
+    return key;
+  });
+  return formatted.join();
+}
+
+export function missingSubFields(field: string, meta: any) {
+  const [key, children] = fieldTuple(readField(field));
+  if (!meta) {
+    return field;
+  }
+  if (children.length) {
+    const missing = filterNotInMeta(children, meta.associatedEntity);
+    // Stringify expects list of fieldTuples
+    return stringify([[key, missing]]);
+  }
+  return false;
+}
+
+export function filterNotInMeta(fields: FieldSyntaxTree, meta: any) {
+  return fields
+    .map((field) => {
+      const [key, children] = fieldTuple(field);
+      // Check if nested field exists for the associatedEntity
+      const def = meta && meta.fields.find((f) => f.name === key);
+      if (!def) {
+        // If not return unparsed field
+        return field;
+      }
+      if (children.length) {
+        // If meta exists and requested child fields filter out fields that are known
+        const missing = filterNotInMeta(children, def.associatedEntity);
+        if (missing.length) {
+          // If there are missing fields return them
+          return [key, missing];
+        }
+      }
+      // If all fields are known return null
+      return null;
+    })
+    .filter(Boolean); // Filter out nulls
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './Lazy';
 export * from './Memory';
 export * from './QueryString';
 export * from './Browser';
+export * from './FieldUtils';

--- a/test/FieldUtils.spec.ts
+++ b/test/FieldUtils.spec.ts
@@ -1,0 +1,133 @@
+import { readField, readFields, stringify, missingSubFields } from '../src';
+
+describe('FieldUtils', () => {
+  expect.extend({
+    toBeSameArray(received, argument) {
+      const expected = JSON.stringify(received);
+      const comparison = JSON.stringify(argument);
+      const pass = expected === comparison;
+      if (pass) {
+        return {
+          pass: true,
+          message: () => `expected value: \n${expected}\nnot to be equal to:\n${comparison}`,
+        };
+      }
+      return {
+        pass: false,
+        message: () => `expected value: \n${expected}\nto be equal to:\n${comparison}`,
+      };
+    },
+  });
+
+  describe('function: readField', () => {
+    it('should parse regular field', () => {
+      const field = 'name';
+      const res = readField(field);
+      expect(res).toBe('name');
+    });
+    it('should parse nested field', () => {
+      const field = 'jobOrders(id,title,status)';
+      const res = readField(field);
+      expect(res).toBeSameArray(['jobOrders', ['id', 'title', 'status']]);
+    });
+    it('should parse nested field and ignore query and count syntax', () => {
+      // tslint:disable-next-line: quotemark
+      const field = `businessSectors[3](name,id){name='Insurance'}`;
+      const res = readField(field);
+      expect(res).toBeSameArray(['businessSectors', ['name', 'id']]);
+    });
+    it('should parse double nested field', () => {
+      const field = 'placement(id,candidate(id,name))';
+      const res = readField(field);
+      expect(res).toBeSameArray(['placement', ['id', ['candidate', ['id', 'name']]]]);
+    });
+  });
+
+  describe('function: readFields', () => {
+    it('should the whole fields string', () => {
+      const fields = 'id,title,placement(id,candidate(id,name))';
+      const res = readFields(fields);
+      expect(res).toBeSameArray(['id', 'title', ['placement', ['id', ['candidate', ['id', 'name']]]]]);
+    });
+  });
+
+  describe('function: stringify', () => {
+    it('should write the string back', () => {
+      const fields = 'id,title,placement(id,candidate(id,name))';
+      const res = readFields(fields);
+      const str = stringify(res);
+      expect(str).toBe(fields);
+    });
+  });
+
+  describe('function: missingSubFields', () => {
+    it('should return whole field request when no meta is present', () => {
+      const fields = 'placement(id,candidate(id,name))';
+      const res = missingSubFields(fields, null);
+      expect(res).toBe(fields);
+    });
+
+    it('should extract only missing fields', () => {
+      const fields = 'placement(id,candidate(id,name,address))';
+      const meta = {
+        associatedEntity: {
+          fields: [
+            { name: 'id' },
+            {
+              name: 'candidate',
+              associatedEntity: {
+                fields: [{ name: 'id' }, { name: 'name' }],
+              },
+            },
+          ],
+        },
+      };
+      const res = missingSubFields(fields, meta);
+      expect(res).toBe('placement(candidate(address))');
+    });
+
+    it('should extract only missing fields when multiple nested fields', () => {
+      const fields = 'placement(id,payRate,candidate(id,name,address),jobOrder(id,status,title))';
+      const meta = {
+        associatedEntity: {
+          fields: [
+            { name: 'id' },
+            {
+              name: 'candidate',
+              associatedEntity: {
+                fields: [{ name: 'id' }, { name: 'name' }],
+              },
+            },
+            {
+              name: 'jobOrder',
+              associatedEntity: {
+                fields: [{ name: 'id' }, { name: 'title' }],
+              },
+            },
+          ],
+        },
+      };
+      const res = missingSubFields(fields, meta);
+      expect(res).toBe('placement(payRate,candidate(address),jobOrder(status))');
+    });
+
+    it('should extract missing fields when missing nested root field', () => {
+      const fields = 'placement(id,payRate,candidate(id,name,address),jobOrder(id,status,title))';
+      const meta = {
+        associatedEntity: {
+          fields: [
+            { name: 'id' },
+            {
+              name: 'candidate',
+              associatedEntity: {
+                fields: [{ name: 'id' }, { name: 'name' }],
+              },
+            },
+          ],
+        },
+      };
+      const res = missingSubFields(fields, meta);
+      expect(res).toBe('placement(payRate,candidate(address),jobOrder(id,status,title))');
+    });
+  });
+});

--- a/test/MetaService.spec.ts
+++ b/test/MetaService.spec.ts
@@ -53,36 +53,42 @@ describe('MetaService', () => {
     });
     it('should return array of fields case 1', () => {
       const meta: MetaService = new MetaService('Candidate');
-      const fields = 'id,name';
-      const res = meta.getSubFields(fields);
+      const field = 'jobOrders(id,title,status)';
+      const res = meta.getSubFields(field);
       expect(res[0]).toBe('id');
-      expect(res[1]).toBe('name');
+      expect(res[1]).toBe('title');
+      expect(res[2]).toBe('status');
     });
     it('should return array of fields case 2', () => {
       const meta: MetaService = new MetaService('Candidate');
-      const fields = 'id,name,jobOrders(id,title,status)';
-      const res = meta.getSubFields(fields);
+      const field = 'jobOrders[3](id,title,status)';
+      const res = meta.getSubFields(field);
       expect(res[0]).toBe('id');
-      expect(res[1]).toBe('name');
-      expect(res[2]).toBe('jobOrders(id,title,status)');
+      expect(res[1]).toBe('title');
+      expect(res[2]).toBe('status');
     });
     it('should return array of fields case 3', () => {
       const meta: MetaService = new MetaService('Candidate');
-      const fields = 'id,name,jobOrders[5]{status=\'closed\'}(id,title)';
-      const res = meta.getSubFields(fields);
+      const field = 'jobOrders{status=\'closed\'}(id,title,status)';
+      const res = meta.getSubFields(field);
       expect(res[0]).toBe('id');
-      expect(res[1]).toBe('name');
-      expect(res[2]).toBe('jobOrders(id,title)');
+      expect(res[1]).toBe('title');
+      expect(res[2]).toBe('status');
+    });
+    it('should return array of fields case 3', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const field = 'jobOrders(id, title, status)';
+      const res = meta.getSubFields(field);
+      expect(res[0]).toBe('id');
+      expect(res[1]).toBe('title');
+      expect(res[2]).toBe('status');
     });
     it('should return array of fields case 4', () => {
       const meta: MetaService = new MetaService('Candidate');
-      const fields = 'id, name, jobOrders(id,title), businessSectors[3](name,id){name=\'Insurance\'}, category';
+      const fields = ' businessSectors[3](name,id){name=\'Insurance\'}, category';
       const res = meta.getSubFields(fields);
-      expect(res[0]).toBe('id');
-      expect(res[1]).toBe('name');
-      expect(res[2]).toBe('jobOrders(id,title)');
-      expect(res[3]).toBe('businessSectors(name,id)');
-      expect(res[4]).toBe('category');
+      expect(res[0]).toBe('name');
+      expect(res[1]).toBe('id');
     });
   });
 

--- a/test/MetaService.spec.ts
+++ b/test/MetaService.spec.ts
@@ -1,47 +1,120 @@
 import { MetaService } from '../src';
 
 describe('MetaService', () => {
-    describe('function: hasMemory', () => {
-        it('should be defined', () => {
-            const meta: MetaService = new MetaService('Candidate');
-            const actual = meta.hasMemory;
-            expect(actual).toBeDefined();
-        });
-        it('should return false when memory is undefined', () => {
-            const meta: MetaService = new MetaService('Candidate');
-            meta.memory = undefined;
-            const actual = meta.hasMemory();
-            expect(actual).toEqual(false);
-        });
-        it('should return false when memory is null', () => {
-            const meta: MetaService = new MetaService('Candidate');
-            meta.memory = null;
-            const actual = meta.hasMemory();
-            expect(actual).toEqual(false);
-        });
-        it('should return false when memory is false', () => {
-            const meta: MetaService = new MetaService('Candidate');
-            meta.memory = false;
-            const actual = meta.hasMemory();
-            expect(actual).toEqual(false);
-        });
-        it('should return false when memory is not an Object', () => {
-            const meta: MetaService = new MetaService('Candidate');
-            meta.memory = [];
-            const actual = meta.hasMemory();
-            expect(actual).toEqual(false);
-        });
-        it('should return false when memory is an empty Object', () => {
-            const meta: MetaService = new MetaService('Candidate');
-            meta.memory = {};
-            const actual = meta.hasMemory();
-            expect(actual).toEqual(false);
-        });
-        it('should return true when memory is a non-empty Object', () => {
-            const meta: MetaService = new MetaService('Candidate');
-            meta.memory = { test: 'test' };
-            const actual = meta.hasMemory();
-            expect(actual).toEqual(true);
-        });
+  describe('function: hasMemory', () => {
+    it('should be defined', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const actual = meta.hasMemory;
+      expect(actual).toBeDefined();
     });
+    it('should return false when memory is undefined', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      meta.memory = undefined;
+      const actual = meta.hasMemory();
+      expect(actual).toEqual(false);
+    });
+    it('should return false when memory is null', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      meta.memory = null;
+      const actual = meta.hasMemory();
+      expect(actual).toEqual(false);
+    });
+    it('should return false when memory is false', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      meta.memory = false;
+      const actual = meta.hasMemory();
+      expect(actual).toEqual(false);
+    });
+    it('should return false when memory is not an Object', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      meta.memory = [];
+      const actual = meta.hasMemory();
+      expect(actual).toEqual(false);
+    });
+    it('should return false when memory is an empty Object', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      meta.memory = {};
+      const actual = meta.hasMemory();
+      expect(actual).toEqual(false);
+    });
+    it('should return true when memory is a non-empty Object', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      meta.memory = {test: 'test'};
+      const actual = meta.hasMemory();
+      expect(actual).toEqual(true);
+    });
+  });
+
+  describe('function: getSubFields', () => {
+    it('should be defined', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const actual = meta.getSubFields;
+      expect(actual).toBeDefined();
+    });
+    it('should return array of fields case 1', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const fields = 'id,name';
+      const res = meta.getSubFields(fields);
+      expect(res[0]).toBe('id');
+      expect(res[1]).toBe('name');
+    });
+    it('should return array of fields case 2', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const fields = 'id,name,jobOrders(id,title,status)';
+      const res = meta.getSubFields(fields);
+      expect(res[0]).toBe('id');
+      expect(res[1]).toBe('name');
+      expect(res[2]).toBe('jobOrders(id,title,status)');
+    });
+    it('should return array of fields case 3', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const fields = 'id,name,jobOrders[5]{status=\'closed\'}(id,title)';
+      const res = meta.getSubFields(fields);
+      expect(res[0]).toBe('id');
+      expect(res[1]).toBe('name');
+      expect(res[2]).toBe('jobOrders(id,title)');
+    });
+    it('should return array of fields case 4', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const fields = 'id, name, jobOrders(id,title), businessSectors[3](name,id){name=\'Insurance\'}, category';
+      const res = meta.getSubFields(fields);
+      expect(res[0]).toBe('id');
+      expect(res[1]).toBe('name');
+      expect(res[2]).toBe('jobOrders(id,title)');
+      expect(res[3]).toBe('businessSectors(name,id)');
+      expect(res[4]).toBe('category');
+    });
+  });
+
+  describe('function: _clean', () => {
+    it('should be defined', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const actual = meta._clean;
+      expect(actual).toBeDefined();
+    });
+    it('should return a field name case 1', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const field = 'name';
+      const res = meta._clean(field);
+      expect(res).toBe('name');
+    });
+    it('should return a field name case 2', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const field = 'jobOrder(id,title)';
+      const res = meta._clean(field);
+      expect(res).toBe('jobOrder');
+    });
+    it('should return a field name case 3', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const field = 'jobOrder[3](id,title)';
+      const res = meta._clean(field);
+      expect(res).toBe('jobOrder');
+    });
+    it('should return a field name case 4', () => {
+      const meta: MetaService = new MetaService('Candidate');
+      const field = 'jobOrder.title';
+      const res = meta._clean(field);
+      expect(res).toBe('jobOrder');
+    });
+  });
 });

--- a/test/MetaService.spec.ts
+++ b/test/MetaService.spec.ts
@@ -47,12 +47,20 @@ describe('MetaService', () => {
 
   describe('function: getSubFields', () => {
     it('should be defined', () => {
-      const meta: MetaService = new MetaService('Candidate');
+      const meta: MetaService = new MetaService('EarnCodeGroup');
       const actual = meta.getSubFields;
       expect(actual).toBeDefined();
     });
     it('should return array of fields case 1', () => {
-      const meta: MetaService = new MetaService('Candidate');
+      const meta: MetaService = new MetaService('EarnCodeGroup');
+      const field = 'jobOrders(id,title,status)';
+      const res = meta.getSubFields(field);
+      expect(res[0]).toBe('id');
+      expect(res[1]).toBe('title');
+      expect(res[2]).toBe('status');
+    });
+    it('should return array of fields case 1', () => {
+      const meta: MetaService = new MetaService('EarnCodeGroup');
       const field = 'jobOrders(id,title,status)';
       const res = meta.getSubFields(field);
       expect(res[0]).toBe('id');
@@ -60,7 +68,7 @@ describe('MetaService', () => {
       expect(res[2]).toBe('status');
     });
     it('should return array of fields case 2', () => {
-      const meta: MetaService = new MetaService('Candidate');
+      const meta: MetaService = new MetaService('EarnCodeGroup');
       const field = 'jobOrders[3](id,title,status)';
       const res = meta.getSubFields(field);
       expect(res[0]).toBe('id');
@@ -68,7 +76,7 @@ describe('MetaService', () => {
       expect(res[2]).toBe('status');
     });
     it('should return array of fields case 3', () => {
-      const meta: MetaService = new MetaService('Candidate');
+      const meta: MetaService = new MetaService('EarnCodeGroup');
       const field = 'jobOrders{status=\'closed\'}(id,title,status)';
       const res = meta.getSubFields(field);
       expect(res[0]).toBe('id');
@@ -76,7 +84,7 @@ describe('MetaService', () => {
       expect(res[2]).toBe('status');
     });
     it('should return array of fields case 3', () => {
-      const meta: MetaService = new MetaService('Candidate');
+      const meta: MetaService = new MetaService('EarnCodeGroup');
       const field = 'jobOrders(id, title, status)';
       const res = meta.getSubFields(field);
       expect(res[0]).toBe('id');
@@ -84,7 +92,7 @@ describe('MetaService', () => {
       expect(res[2]).toBe('status');
     });
     it('should return array of fields case 4', () => {
-      const meta: MetaService = new MetaService('Candidate');
+      const meta: MetaService = new MetaService('EarnCodeGroup');
       const fields = ' businessSectors[3](name,id){name=\'Insurance\'}, category';
       const res = meta.getSubFields(fields);
       expect(res[0]).toBe('name');

--- a/test/MetaService.spec.ts
+++ b/test/MetaService.spec.ts
@@ -93,7 +93,7 @@ describe('MetaService', () => {
     });
     it('should return array of fields case 5', () => {
       const meta: MetaService = new MetaService('EarnCodeGroup');
-      const fields = ' businessSectors[3](name,id){name=\'Insurance\'}, category';
+      const fields = 'businessSectors[3](name,id){name=\'Insurance\'},category';
       const res = meta.getSubFields(fields);
       expect(res[0]).toBe('name');
       expect(res[1]).toBe('id');

--- a/test/MetaService.spec.ts
+++ b/test/MetaService.spec.ts
@@ -83,7 +83,7 @@ describe('MetaService', () => {
       expect(res[1]).toBe('title');
       expect(res[2]).toBe('status');
     });
-    it('should return array of fields case 3', () => {
+    it('should return array of fields case 4', () => {
       const meta: MetaService = new MetaService('EarnCodeGroup');
       const field = 'jobOrders(id, title, status)';
       const res = meta.getSubFields(field);
@@ -91,7 +91,7 @@ describe('MetaService', () => {
       expect(res[1]).toBe('title');
       expect(res[2]).toBe('status');
     });
-    it('should return array of fields case 4', () => {
+    it('should return array of fields case 5', () => {
       const meta: MetaService = new MetaService('EarnCodeGroup');
       const fields = ' businessSectors[3](name,id){name=\'Insurance\'}, category';
       const res = meta.getSubFields(fields);

--- a/test/MetaService.spec.ts
+++ b/test/MetaService.spec.ts
@@ -39,64 +39,31 @@ describe('MetaService', () => {
     });
     it('should return true when memory is a non-empty Object', () => {
       const meta: MetaService = new MetaService('Candidate');
-      meta.memory = {test: 'test'};
+      meta.memory = { test: 'test' };
       const actual = meta.hasMemory();
       expect(actual).toEqual(true);
     });
   });
 
-  describe('function: getSubFields', () => {
+  describe('function: missing', () => {
     it('should be defined', () => {
       const meta: MetaService = new MetaService('EarnCodeGroup');
-      const actual = meta.getSubFields;
+      const actual = meta.missing;
       expect(actual).toBeDefined();
     });
     it('should return array of fields case 1', () => {
       const meta: MetaService = new MetaService('EarnCodeGroup');
-      const field = 'jobOrders(id,title,status)';
-      const res = meta.getSubFields(field);
-      expect(res[0]).toBe('id');
-      expect(res[1]).toBe('title');
-      expect(res[2]).toBe('status');
-    });
-    it('should return array of fields case 1', () => {
-      const meta: MetaService = new MetaService('EarnCodeGroup');
-      const field = 'jobOrders(id,title,status)';
-      const res = meta.getSubFields(field);
-      expect(res[0]).toBe('id');
-      expect(res[1]).toBe('title');
-      expect(res[2]).toBe('status');
-    });
-    it('should return array of fields case 2', () => {
-      const meta: MetaService = new MetaService('EarnCodeGroup');
-      const field = 'jobOrders[3](id,title,status)';
-      const res = meta.getSubFields(field);
-      expect(res[0]).toBe('id');
-      expect(res[1]).toBe('title');
-      expect(res[2]).toBe('status');
-    });
-    it('should return array of fields case 3', () => {
-      const meta: MetaService = new MetaService('EarnCodeGroup');
-      const field = 'jobOrders{status=\'closed\'}(id,title,status)';
-      const res = meta.getSubFields(field);
-      expect(res[0]).toBe('id');
-      expect(res[1]).toBe('title');
-      expect(res[2]).toBe('status');
-    });
-    it('should return array of fields case 4', () => {
-      const meta: MetaService = new MetaService('EarnCodeGroup');
-      const field = 'jobOrders(id, title, status)';
-      const res = meta.getSubFields(field);
-      expect(res[0]).toBe('id');
-      expect(res[1]).toBe('title');
-      expect(res[2]).toBe('status');
-    });
-    it('should return array of fields case 5', () => {
-      const meta: MetaService = new MetaService('EarnCodeGroup');
-      const fields = 'businessSectors[3](name,id){name=\'Insurance\'},category';
-      const res = meta.getSubFields(fields);
-      expect(res[0]).toBe('name');
-      expect(res[1]).toBe('id');
+      const associatedEntity = { fields: [{ name: 'id' }] };
+      meta.memory = {
+        id: { name: 'id' },
+        candidate: { name: 'candidate', associatedEntity },
+        jobOrder: { name: 'jobOrder', associatedEntity },
+      };
+      const fields = ['id', 'payRate', 'candidate(id,name,address)', 'jobOrder(id,status,title)'];
+      const res = meta.missing(fields);
+      expect(res[0]).toBe('payRate');
+      expect(res[1]).toBe('candidate(name,address)');
+      expect(res[2]).toBe('jobOrder(status,title)');
     });
   });
 


### PR DESCRIPTION
An alternative approach to parsing missing fields.  Lots to discuss but check test cases to see approach:

```javascript
      const meta: MetaService = new MetaService('EarnCodeGroup');
      const associatedEntity = { fields: [{ name: 'id' }] };
      meta.memory = {
        id: { name: 'id' },
        candidate: { name: 'candidate', associatedEntity },
        jobOrder: { name: 'jobOrder', associatedEntity },
      };
      const fields = ['id', 'payRate', 'candidate(id,name,address)', 'jobOrder(id,status,title)'];
      const res = meta.missing(fields);
      expect(res[0]).toBe('payRate');
      expect(res[1]).toBe('candidate(name,address)');
      expect(res[2]).toBe('jobOrder(status,title)');
```