### PR TITLE
feat(Searcher): Ignore old data from long running filter responses

### DIFF
--- a/src/core/EntityList.ts
+++ b/src/core/EntityList.ts
@@ -69,13 +69,12 @@ export class EntityList<T> extends StatefulSubject<T[]> {
       this.$list.then((results: BullhornListResponse<T>) => {
         this.descriptor = results.meta;
         this.$latest = results;
-        if (results.timestamp) {
-          // Ignore responses that are for older requests when we have a newer completed request
-          if (results.timestamp > this.latestTimestamp) {
-            this.latestTimestamp = results.timestamp;
-            this.next(results.data);
-          }
-        } else {
+        if (!results.timestamp) {
+          return this.next(results.data);
+        }
+        // Ignore responses that are for older requests when we have a newer completed request
+        if (results.timestamp > this.latestTimestamp) {
+          this.latestTimestamp = results.timestamp;
           this.next(results.data);
         }
       }, error => {

--- a/src/services/QueryService.ts
+++ b/src/services/QueryService.ts
@@ -97,6 +97,7 @@ export class QueryService<T> {
   }
   async run(add: boolean): Promise<BullhornListResponse<T>> {
     await this.initialized;
+    const requestTimestamp = Date.now();
     const [response, metadata] = await Promise.all([this.httpGet(this.parameters), this.meta.getFull(this.parameters.fields, this.parameters.layout)]);
     const result = response.data;
     if (this.shouldPullMoreRecords(result)) {
@@ -112,6 +113,7 @@ export class QueryService<T> {
       this.records = result.data;
     }
     result.meta = metadata;
+    result.timestamp = requestTimestamp;
     return result;
   }
 

--- a/src/types/Responses.ts
+++ b/src/types/Responses.ts
@@ -89,6 +89,7 @@ export interface BullhornListResponse<T> {
   data: T[];
   messages?: BullhornMessage[];
   meta?: BullhornMetaResponse;
+  timestamp?: number;
 }
 
 export interface BullhornEntityResponse<T> {


### PR DESCRIPTION
Currently, for filter results that take a long time to resolve, if the user types in filter text slowly, then the results that come back are not in chronological order, leading to incorrect results that do not match the current filter text.

For example, the user types:

`b` => query A
`bu` => query B
`bull` => query C

But the responses come back as:

response C => `5 results`
response B => `500 results`
response A => `5000 results`

And so what the user sees on their screen is an immediate 5 results, followed by more and more results that don't match the current query. 

This introduces an optional timestamp that will ignore previous results that were initiated prior to the latest.

See video for repro.

https://user-images.githubusercontent.com/3843503/166277915-fe7c8e52-8876-4b91-a062-200fd67cfd71.mov


