### PR TITLE
chore: Remove broken badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 ---
 
-[![Dependency Status](https://dependencyci.com/github/bullhorn/taurus/badge)](https://dependencyci.com/github/bullhorn/taurus)
 [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 [![npm version](https://badge.fury.io/js/%40bullhorn%2Ftaurus.svg)](https://badge.fury.io/js/%40bullhorn%2Ftaurus)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
The badge for <https://dependencyci.com/> is broken due to the company being bought by Tidelift so we can probably remove it?